### PR TITLE
Small update & bug fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ WORKDIR /app
 ENV PRISMO_CONFIG=/app/external/config_docker.json
 
 RUN apt-get update && apt-get install -y jo git
+RUN apt-get install -y tzdata
+
+ENV TZ=Europe/Kyiv
 
 COPY requirements.txt /app
 RUN pip3 install -r requirements.txt

--- a/app/plugins/slack_notifier/slack_notifier.py
+++ b/app/plugins/slack_notifier/slack_notifier.py
@@ -73,7 +73,7 @@ def door_message_block_constructor(door, user):
                         },
                         {
                             "type": "text",
-                            "text": " entered through the "
+                            "text": " opened "
                         },
                         {
                             "type": "text",

--- a/data/config_docker.json
+++ b/data/config_docker.json
@@ -21,7 +21,8 @@
         ],
         "PLUGINS": {
             "slack_notifier": {
-                "SLACK_CHANNEL": "#prismo-debug",
+                "SLACK_DOOR_CHANNEL": "#prismo-debug",
+                "SLACK_TOOL_CHANNEL": "#prismo-debug",
                 "SLACK_TOKEN": "xoxb-this-is-not-areal-slack-token"
             }
         },

--- a/docs/rpi_installation_instructions.md
+++ b/docs/rpi_installation_instructions.md
@@ -41,7 +41,7 @@ sudo reboot
 ```commandline
 git clone https://github.com/hacklabkyiv/prismo.git
 cd prismo
-./docker-run.sh
+./docker_run.sh
 ```
 
 


### PR DESCRIPTION
In config_docker.json SLACK_CHANNEL does not work when setting up a Slack app. Supposed to be separate tool and door channels here to post messages correctly.

In the installation instructions file name in suggested command is wrong

In the text posted to Slack channel phrase XX "entered through the" YY clutters the log and is redundant. Just "opened" will suffice.

User is not able to set up time zone in docker container (default +0:0) which results in incorrect time displayed in the logs and key activations. Added a timezone selection to Dockerfile